### PR TITLE
Fix lsp-jedi-executable-args type mismatch

### DIFF
--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -45,7 +45,7 @@
   :type 'string
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-executable-args []
+(defcustom lsp-jedi-executable-args nil
   "Specify the args list passed to your executable."
   :type '(repeat string)
   :group 'lsp-jedi)


### PR DESCRIPTION
As titled