### PR TITLE
Fix init options

### DIFF
--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -117,10 +117,7 @@ Run on in-memory document change (eg, while you're editing, without needing to s
   :priority -1
   :server-id 'jedi
   :library-folders-fn (lambda (_workspace) lsp-jedi-python-library-directories)
-  :initialized-fn (lambda (workspace)
-                    (with-lsp-workspace
-                     workspace
-                     (lsp--set-configuration (lsp-configuration-section "jedi"))))))
+  :initialization-options (lambda () (json-read-from-string (json-encode (lsp-configuration-section "jedi"))))))
 
 (provide 'lsp-jedi)
 ;;; lsp-jedi.el ends here

--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -111,18 +111,18 @@ autocompletion performance but loses goto definition."
   :package-version '(lsp-mode . "6.1"))
 
 (lsp-register-custom-settings
-  '(("jedi.enable" lsp-jedi-enable)
-    ("jedi.startupMessage" lsp-jedi-startup-message)
-    ("jedi.markupKindPreferred" lsp-jedi-markup-kind-preferred)
-    ("jedi.trace.server" lsp-jedi-trace-server)
-    ("jedi.jediSettings.autoImportModules" lsp-jedi-auto-import-modules)
-    ("jedi.executable.command" lsp-jedi-executable-command)
-    ("jedi.executable.args" lsp-jedi-executable-args)
-    ("jedi.completion.disableSnippets" lsp-jedi-completion-disable-snippets t)
-    ("jedi.diagnostics.enable" lsp-jedi-diagnostics-enable t)
-    ("jedi.diagnostics.didOpen" lsp-jedi-diagnostics-did-open t)
-    ("jedi.diagnostics.didChange" lsp-jedi-diagnostics-did-change t)
-    ("jedi.diagnostics.didSave" lsp-jedi-diagnostics-did-save t)))
+ '(("jedi.enable" lsp-jedi-enable)
+   ("jedi.startupMessage" lsp-jedi-startup-message)
+   ("jedi.markupKindPreferred" lsp-jedi-markup-kind-preferred)
+   ("jedi.trace.server" lsp-jedi-trace-server)
+   ("jedi.jediSettings.autoImportModules" lsp-jedi-auto-import-modules)
+   ("jedi.executable.command" lsp-jedi-executable-command)
+   ("jedi.executable.args" lsp-jedi-executable-args)
+   ("jedi.completion.disableSnippets" lsp-jedi-completion-disable-snippets t)
+   ("jedi.diagnostics.enable" lsp-jedi-diagnostics-enable t)
+   ("jedi.diagnostics.didOpen" lsp-jedi-diagnostics-did-open t)
+   ("jedi.diagnostics.didChange" lsp-jedi-diagnostics-did-change t)
+   ("jedi.diagnostics.didSave" lsp-jedi-diagnostics-did-save t)))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -57,16 +57,16 @@
 
 (defcustom lsp-jedi-markup-kind-preferred nil
   "Type of markup."
-  :type  '(choice (const :tag "plaintext" plaintext)
-                  (const :tag "markdown" markdown)
-                  (const :tag "none" nil))
+  :type  '(choice (const :tag "Plain text" "plaintext")
+                  (const :tag "Markdown" "markdown")
+                  (other :tag "None" nil))
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-trace-server 'verbose
+(defcustom lsp-jedi-trace-server "verbose"
   "Trace server."
-  :type '(choice (const :tag "off" nil)
-                 (const :tag "messages" messages)
-                 (const :tag "verbose" verbose))
+  :type '(choice (const :tag "Disabled" "off")
+                 (const :tag "Messages" "messages")
+                 (const :tag "Verbose" "verbose"))
   :group 'lsp-jedi)
 
 (defcustom lsp-jedi-diagnostics-enable nil

--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -90,6 +90,19 @@ Run on in-memory document change (eg, while you're editing, without needing to s
   :type 'boolean
   :group 'lsp-jedi)
 
+(defcustom lsp-jedi-completion-disable-snippets nil
+  "If your language client supports CompletionItem snippets but
+you don't like them, disable them by setting this option to a
+non-nil value."
+  :type 'boolean
+  :group 'lsp-jedi)
+
+(defcustom lsp-jedi-auto-import-modules nil
+  "Modules that will not be analyzed but imported. Improves
+autocompletion performance but loses goto definition."
+  :type '(repeat (string))
+  :group 'lsp-jedi)
+
 (defcustom lsp-jedi-python-library-directories '("/usr/")
   "List of directories which will be considered to be libraries."
   :risky t
@@ -102,12 +115,14 @@ Run on in-memory document change (eg, while you're editing, without needing to s
     ("jedi.startupMessage" lsp-jedi-startup-message)
     ("jedi.markupKindPreferred" lsp-jedi-markup-kind-preferred)
     ("jedi.trace.server" lsp-jedi-trace-server)
+    ("jedi.jediSettings.autoImportModules" lsp-jedi-auto-import-modules)
     ("jedi.executable.command" lsp-jedi-executable-command)
     ("jedi.executable.args" lsp-jedi-executable-args)
-    ("jedi.diagnostics.enable" lsp-jedi-diagnostics-enable)
-    ("jedi.diagnostics.didOpen" lsp-jedi-diagnostics-did-open)
-    ("jedi.diagnostics.didChange" lsp-jedi-diagnostics-did-change)
-    ("jedi.diagnostics.didSave" lsp-jedi-diagnostics-did-save)))
+    ("jedi.completion.disableSnippets" lsp-jedi-completion-disable-snippets t)
+    ("jedi.diagnostics.enable" lsp-jedi-diagnostics-enable t)
+    ("jedi.diagnostics.didOpen" lsp-jedi-diagnostics-did-open t)
+    ("jedi.diagnostics.didChange" lsp-jedi-diagnostics-did-change t)
+    ("jedi.diagnostics.didSave" lsp-jedi-diagnostics-did-save t)))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -45,9 +45,9 @@
   :type 'string
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-executable-args nil
+(defcustom lsp-jedi-executable-args []
   "Specify the args list passed to your executable."
-  :type '(repeat string)
+  :type 'lsp-string-vector
   :group 'lsp-jedi)
 
 (defcustom lsp-jedi-startup-message nil
@@ -97,16 +97,16 @@ non-nil value."
   :type 'boolean
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-auto-import-modules nil
+(defcustom lsp-jedi-auto-import-modules []
   "Modules that will not be analyzed but imported. Improves
 autocompletion performance but loses goto definition."
-  :type '(repeat (string))
+  :type 'lsp-string-vector
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-python-library-directories '("/usr/")
+(defcustom lsp-jedi-python-library-directories ["/usr/"]
   "List of directories which will be considered to be libraries."
   :risky t
-  :type '(repeat string)
+  :type 'lsp-string-vector
   :group 'lsp-jedi
   :package-version '(lsp-mode . "6.1"))
 
@@ -132,7 +132,7 @@ autocompletion performance but loses goto definition."
   :priority -1
   :server-id 'jedi
   :library-folders-fn (lambda (_workspace) lsp-jedi-python-library-directories)
-  :initialization-options (lambda () (json-read-from-string (json-encode (lsp-configuration-section "jedi"))))))
+  :initialization-options (lambda () (lsp-configuration-section "jedi"))))
 
 (provide 'lsp-jedi)
 ;;; lsp-jedi.el ends here

--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -45,7 +45,7 @@
   :type 'string
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-executable-args []
+(defcustom lsp-jedi-executable-args nil
   "Specify the args list passed to your executable."
   :type '(repeat string)
   :group 'lsp-jedi)

--- a/lsp-jedi.el
+++ b/lsp-jedi.el
@@ -103,10 +103,10 @@ autocompletion performance but loses goto definition."
   :type 'lsp-string-vector
   :group 'lsp-jedi)
 
-(defcustom lsp-jedi-python-library-directories ["/usr/"]
+(defcustom lsp-jedi-python-library-directories '("/usr/")
   "List of directories which will be considered to be libraries."
   :risky t
-  :type 'lsp-string-vector
+  :type '(repeat string)
   :group 'lsp-jedi
   :package-version '(lsp-mode . "6.1"))
 


### PR DESCRIPTION
This PR fixes 4 things:

1. Type error in lsp-jedi-executable-args
2. #3 due to init params sent in a `workspace/didChangeConfiguration` message instead of an `initializationOption` param in the initialize message.
3. Add all new supported config from jedi-language-server
4. A few defcustoms can't be filtered out when set to nil because lsp-mode will think it's an empty list, and also jedi-language-server actually accepts strings instead of booleans.